### PR TITLE
Skip Validation (optional)

### DIFF
--- a/routes/routes121.py
+++ b/routes/routes121.py
@@ -236,6 +236,14 @@ async def kobo_update_121(
                 target_response = response.content.decode("utf-8")
                 logger.info(target_response)
 
+    # Check if 'skipvalidation' is present and set to True in kobo_data
+    if "skipvalidation" in kobo_data.keys() and kobo_data["skipvalidation"] == "1":
+        logger.info("Skipping validation status update", extra=extra_logs)
+        update_response_message = response.content.decode("utf-8")
+        return JSONResponse(
+            status_code=response.status_code, content=update_response_message
+        )
+
     status_response = requests.patch(
         f"{request.headers['url121']}/api/programs/{programid}/registrations/status?dryRun=false&filter.referenceId=$in:{referenceId}",
         headers={"Cookie": f"access_token_general={access_token}"},

--- a/routes/routes121.py
+++ b/routes/routes121.py
@@ -239,9 +239,8 @@ async def kobo_update_121(
     # Check if 'skipvalidation' is present and set to True in kobo_data
     if "skipvalidation" in kobo_data.keys() and kobo_data["skipvalidation"] == "1":
         logger.info("Skipping validation status update", extra=extra_logs)
-        update_response_message = response.content.decode("utf-8")
         return JSONResponse(
-            status_code=response.status_code, content=update_response_message
+            status_code=200, content={"message": "Skipping validation status update"}
         )
 
     status_response = requests.patch(

--- a/tests/test_koboupdate121.py
+++ b/tests/test_koboupdate121.py
@@ -1,6 +1,7 @@
 import sys
 import os
 import json
+from unittest.mock import patch
 from fastapi.testclient import TestClient
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
@@ -35,3 +36,29 @@ def test_kobo_to_121_payload():
             "reason": "Validated during field validation",
         }
     }
+
+
+@patch("routes.routes121.login121")
+@patch("routes.routes121.requests.patch")
+def test_kobo_update_121_skip_validation(mock_patch, mock_login):
+    """Test that skipvalidation=1 skips the validation status PATCH call."""
+    mock_login.return_value = "fake_token"
+
+    mock_response = mock_patch.return_value
+    mock_response.status_code = 200
+    mock_response.content = b'{"message": "updated"}'
+
+    kobo_data_with_skip = kobo_data.copy()
+    kobo_data_with_skip["skipvalidation"] = "1"
+
+    response = client.post(
+        "/kobo-update-121", headers=kobo_headers, json=kobo_data_with_skip
+    )
+
+    assert response.status_code == 200
+    assert response.json() == {"message": "Skipping validation status update"}
+
+    # Verify status endpoint was never called
+    for call in mock_patch.call_args_list:
+        url = call[0][0] if call[0] else call[1].get("url", "")
+        assert "registrations/status" not in url


### PR DESCRIPTION
Makes the validation status update in the /kobo-update-121 endpoint optional. By default, the endpoint still sets the registration status to "validated" (existing behavior). However, if skipvalidation is set to "1" in the Kobo submission data, the validation PATCH call is skipped.

This follows the same pattern as the existing skipconnect field in /kobo-to-121.